### PR TITLE
Update bankScraper.js

### DIFF
--- a/app/node/bankScraper.js
+++ b/app/node/bankScraper.js
@@ -6,7 +6,7 @@ async function scrape({ companyId, credentials, startDate, showBrowser = false }
   //   console.log('USING MOCK DATA');
   //   return mockTransactions[companyId];
   // }
-  if (!credentials || (!credentials.username && !credentials.num) || !credentials.password) {
+  if (!credentials || (!credentials.username && !credentials.num && !credentials.id) || !credentials.password) {
     throw new Error(`Missing credentials for scraper. CompanyId: ${companyId}. Credentials: ${credentials && JSON.stringify(credentials)}`);
   }
 


### PR DESCRIPTION
don't throw error on credentials that don't have username (like isracard that use id and not username)