### PR TITLE
Edit global config in UI

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,6 +63,7 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': ['error', { args: 'after-used', argsIgnorePattern: '^_|h' }],
     'arrow-body-style': 'off',
     'object-curly-newline': 'warn',
+    'semi': productionError,
   },
 
   overrides: [

--- a/src/components/App/ConfigEditor.vue
+++ b/src/components/App/ConfigEditor.vue
@@ -1,5 +1,8 @@
 <template>
-  <v-form ref="form" v-model="validated">
+  <v-form
+    ref="form"
+    v-model="validated"
+  >
     <v-container>
       <v-row justify="center">
         <v-col class="py-0">
@@ -11,7 +14,10 @@
             @input="updateConfig($event, 'numDaysBack')"
           />
         </v-col>
-        <v-col cols="auto" class="py-0">
+        <v-col
+          cols="auto"
+          class="py-0"
+        >
           <v-checkbox
             label="Show browser"
             :value="storeGlobalConfig.showBrowser"
@@ -21,7 +27,13 @@
       </v-row>
     </v-container>
 
-    <v-btn color="primary" :disabled="!readyToSave" @click="submitForm()">Save</v-btn>
+    <v-btn
+      color="primary"
+      :disabled="!readyToSave"
+      @click="submitForm()"
+    >
+      Save
+    </v-btn>
   </v-form>
 </template>
 
@@ -65,7 +77,7 @@ export default Vue.extend({
       if (this.form.validate()) {
         // TODO the arguments should be simple
         this.updateGlobalConfig({ ...this.storeGlobalConfig, ...this.globalConfig })
-          .then(() => { this.changed = false });
+          .then(() => { this.changed = false; });
       }
     }
   }

--- a/src/components/App/ConfigEditor.vue
+++ b/src/components/App/ConfigEditor.vue
@@ -7,11 +7,11 @@
       <v-row justify="center">
         <v-col class="py-0">
           <v-text-field
+            v-model="globalConfig.numDaysBack"
             type="number"
             label="Days back from today to take"
             :rules="[required, positive]"
-            :value="storeGlobalConfig.numDaysBack"
-            @input="updateConfig($event, 'numDaysBack')"
+            @change="changed = true"
           />
         </v-col>
         <v-col
@@ -19,9 +19,9 @@
           class="py-0"
         >
           <v-checkbox
+            v-model="globalConfig.showBrowser"
             label="Show browser"
-            :value="storeGlobalConfig.showBrowser"
-            @change="updateConfig($event, 'showBrowser')"
+            @change="changed = true"
           />
         </v-col>
       </v-row>
@@ -63,21 +63,23 @@ export default Vue.extend({
       return this.$refs.form as VForm;
     },
   },
+  created() {
+    this.reset();
+  },
   methods: {
     required: (value) => !!value || 'Required.',
     positive: (value: number) => value > 0 || 'Must be grater than 0',
     ...mapActions({
       updateGlobalConfig: UPDATE_GLOBAL_CONFIG_ACTION
     }),
-    updateConfig(value, field): void {
-      this.changed = true;
-      this.globalConfig[field] = value;
+    reset() {
+      this.globalConfig = JSON.parse(JSON.stringify(this.storeGlobalConfig));
+      this.changed = false;
     },
     submitForm() {
       if (this.form.validate()) {
-        // TODO the arguments should be simple
-        this.updateGlobalConfig({ ...this.storeGlobalConfig, ...this.globalConfig })
-          .then(() => { this.changed = false; });
+        this.updateGlobalConfig(this.globalConfig)
+          .then(this.reset);
       }
     }
   }

--- a/src/components/App/ConfigEditor.vue
+++ b/src/components/App/ConfigEditor.vue
@@ -1,0 +1,76 @@
+<template>
+  <v-form ref="form" v-model="validated">
+    <v-container>
+      <v-row justify="center">
+        <v-col class="py-0">
+          <v-text-field
+            type="number"
+            label="Days back from today to take"
+            :rules="[required, positive]"
+            :value="storeGlobalConfig.numDaysBack"
+            @input="updateConfig($event, 'numDaysBack')"
+          />
+        </v-col>
+        <v-col cols="auto" class="py-0">
+          <v-checkbox
+            label="Show browser"
+            :value="storeGlobalConfig.showBrowser"
+            @change="updateConfig($event, 'showBrowser')"
+          />
+        </v-col>
+      </v-row>
+    </v-container>
+
+    <v-btn color="primary" :disabled="!readyToSave" @click="submitForm()">Save</v-btn>
+  </v-form>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { mapGetters, mapActions } from 'vuex';
+import { GLOBAL_CONFIG_GETTER, UPDATE_GLOBAL_CONFIG_ACTION } from '@/store/modules/Config';
+import { VForm } from '@/types/vuetify';
+
+export default Vue.extend({
+  name: 'ConfigEditor',
+  data() {
+    return {
+      globalConfig: {},
+      validated: true,
+      changed: false,
+    };
+  },
+  computed: {
+    ...mapGetters({
+      storeGlobalConfig: GLOBAL_CONFIG_GETTER
+    }),
+    readyToSave(): boolean {
+      return this.validated && this.changed;
+    },
+    form(): VForm {
+      return this.$refs.form as VForm;
+    },
+  },
+  methods: {
+    required: (value) => !!value || 'Required.',
+    positive: (value: number) => value > 0 || 'Must be grater than 0',
+    ...mapActions({
+      updateGlobalConfig: UPDATE_GLOBAL_CONFIG_ACTION
+    }),
+    updateConfig(value, field): void {
+      this.changed = true;
+      this.globalConfig[field] = value;
+    },
+    submitForm() {
+      if (this.form.validate()) {
+        // TODO the arguments should be simple
+        this.updateGlobalConfig({ ...this.storeGlobalConfig, ...this.globalConfig })
+          .then(() => { this.changed = false });
+      }
+    }
+  }
+});
+</script>
+
+<style>
+</style>

--- a/src/components/App/Importers/Importer.vue
+++ b/src/components/App/Importers/Importer.vue
@@ -1,9 +1,5 @@
 <template>
   <v-card>
-    <v-checkbox
-      v-model="showBrowser"
-      label="Show browser"
-    />
     <div
       v-for="(value, credentialFieldName) in importer.loginFields"
       :key="credentialFieldName"
@@ -11,14 +7,6 @@
       {{ credentialFieldName }}:
       {{ credentialFieldName != "password" ? value : "*".repeat(value.length) }}
     </div>
-    <v-btn
-      color="primary"
-      class="mx-1"
-      :loading="importing"
-      @click="scrape()"
-    >
-      Import
-    </v-btn>
     <v-btn
       color="error"
       dark
@@ -32,27 +20,12 @@
       v-model="deleteDialog"
       @confirm="DeleteImporter"
     />
-    <v-progress-linear
-      v-show="importing"
-      v-model="percentage"
-      height="25"
-      reactive
-    >
-      <template v-slot="{ value }">
-        <strong>{{ value }}%</strong>
-      </template>
-    </v-progress-linear>
-    <div v-show="importing">
-      {{ step }}
-    </div>
   </v-card>
 </template>
 
 <script>
 import { mapActions } from 'vuex';
-import { remote } from 'electron';
 import { REMOVE_IMPORTER_ACTION } from '@/store/modules/Config';
-import { scrape } from '@/modules/scrapers';
 import DeleteImporterDialog from './DeleteImporterDialog';
 
 export default {
@@ -67,72 +40,17 @@ export default {
   },
   data() {
     return {
-      importing: false,
-      showBrowser: false,
-      percentage: 0,
-      step: '',
       status: undefined,
       deleteDialog: false,
     };
   },
   methods: {
-    async scrape() {
-      this.importing = true;
-      this.onProgress({ percent: 0, message: `Request to import ${this.importer.key}` });
-      try {
-        const result = await scrape(
-          remote.app.getPath('cache'),
-          this.importer.key,
-          this.importer.loginFields,
-          this.showBrowser,
-          this.onProgress,
-          this.$logger,
-        );
-        if (result.success) {
-          const message = result.accounts
-            .map((account) => `${account.accountNumber} with ${account.txns.length}`).join();
-          this.onProgress({ percent: 1, message });
-          result.accounts.forEach((account) => {
-            this.addTransactionsAction(account);
-          });
-        } else {
-          const message = result.errorMessage || result.errorType;
-          this.onProgress({ percent: 1, message, error: message });
-        }
-      } catch (error) {
-        this.onProgress({ percent: 1, message: error.message, error });
-      }
-    },
-    onProgress({ percent, message, error }) {
-      if (percent === undefined) throw new Error('You must to set \'percent\' value for progress');
-      this.percentage = Math.floor(percent * 100);
-      if (message) {
-        this.step = message;
-        this.$logger.info(message);
-      }
-      if (error) {
-        this.$logger.error(error.message);
-        if (error.stack) this.$logger.verbose(error.stack);
-        this.status = 'exception';
-      }
-      if (percent >= 1) {
-        this.importing = false;
-        const success = this.status !== 'exception' && !error;
-        this.status = success ? 'success' : 'exception';
-        const status = {
-          success,
-          lastMessage: this.step,
-        };
-        this.updateImporterStatus({ id: this.importer.id, status });
-      }
-    },
     DeleteImporter() {
       this.deleteDialog = false;
       this[REMOVE_IMPORTER_ACTION](this.importer.id);
     },
     ...mapActions([
       REMOVE_IMPORTER_ACTION,
-      'addTransactionsAction',
       'updateImporterStatus',
     ]),
   },

--- a/src/components/App/MainContent.vue
+++ b/src/components/App/MainContent.vue
@@ -13,12 +13,16 @@
     <div>
       <log-lines :entries="results" />
     </div>
+    <div>
+      <config-editor />
+    </div>
   </div>
 </template>
 
 <script>
 import { scrapeAndUpdateOutputVendors } from '@/originalBudgetTrackingApp';
 import LogLines from '@/components/shared/LogLines';
+import ConfigEditor from './ConfigEditor';
 
 const colors = {
   true: 'green',
@@ -29,7 +33,7 @@ const colors = {
 export default {
   name: 'MainContent',
   components: {
-    LogLines
+    LogLines, ConfigEditor
   },
   data() {
     return {

--- a/src/originalBudgetTrackingApp/configManager/configManager.ts
+++ b/src/originalBudgetTrackingApp/configManager/configManager.ts
@@ -20,7 +20,7 @@ export interface Config {
     numDaysBack: number;
     showBrowser: boolean;
     accountsToScrape: AccountToScrapeConfig[];
-  }
+  };
   monitoring?: {
     email: {
       sendReport: boolean;

--- a/src/originalBudgetTrackingApp/configManager/configManager.ts
+++ b/src/originalBudgetTrackingApp/configManager/configManager.ts
@@ -16,10 +16,10 @@ export interface Config {
     googleSheets?: GoogleSheetsConfig;
     ynab?: YnabConfig;
   };
-  scraping: {
-    'numDaysBack': number;
-    'showBrowser': boolean;
-    'accountsToScrape': AccountToScrapeConfig[];
+  accountsToScrape: AccountToScrapeConfig[];
+  globalConfig: {
+    numDaysBack: number;
+    showBrowser: boolean;
   };
   monitoring?: {
     email: {

--- a/src/originalBudgetTrackingApp/configManager/configManager.ts
+++ b/src/originalBudgetTrackingApp/configManager/configManager.ts
@@ -16,11 +16,11 @@ export interface Config {
     googleSheets?: GoogleSheetsConfig;
     ynab?: YnabConfig;
   };
-  accountsToScrape: AccountToScrapeConfig[];
-  globalConfig: {
+  scraping: {
     numDaysBack: number;
     showBrowser: boolean;
-  };
+    accountsToScrape: AccountToScrapeConfig[];
+  }
   monitoring?: {
     email: {
       sendReport: boolean;

--- a/src/originalBudgetTrackingApp/configManager/defaultConfig.ts
+++ b/src/originalBudgetTrackingApp/configManager/defaultConfig.ts
@@ -1,12 +1,11 @@
 import { Config } from './configManager';
 
 const DEFAULT_CONFIG: Config = {
-  globalConfig: {
+  scraping: {
     numDaysBack: 40,
-    showBrowser: false
+    showBrowser: false,
+    accountsToScrape: [],
   },
-  accountsToScrape: [
-  ],
   outputVendors: {
     ynab: {
       active: false,

--- a/src/originalBudgetTrackingApp/configManager/defaultConfig.ts
+++ b/src/originalBudgetTrackingApp/configManager/defaultConfig.ts
@@ -1,12 +1,12 @@
 import { Config } from './configManager';
 
 const DEFAULT_CONFIG: Config = {
-  scraping: {
+  globalConfig: {
     numDaysBack: 40,
-    showBrowser: false,
-    accountsToScrape: [
-    ]
+    showBrowser: false
   },
+  accountsToScrape: [
+  ],
   outputVendors: {
     ynab: {
       active: false,

--- a/src/originalBudgetTrackingApp/index.ts
+++ b/src/originalBudgetTrackingApp/index.ts
@@ -25,7 +25,7 @@ export async function scrapeAndUpdateOutputVendors() {
   const config = await configManager.getConfig();
 
   const startDate = moment()
-    .subtract(config.globalConfig.numDaysBack, 'days')
+    .subtract(config.scraping.numDaysBack, 'days')
     .startOf('day')
     .toDate();
 
@@ -47,7 +47,7 @@ export async function scrapeAndUpdateOutputVendors() {
 
 async function scrapeFinancialAccountsAndFetchTransactions(config: Config, startDate: Date) {
   const companyIdToTransactions: Record<string, EnrichedTransaction[]> = {};
-  const accountsToScrape = config.accountsToScrape.filter((accountToScrape) => accountToScrape.active !== false);
+  const accountsToScrape = config.scraping.accountsToScrape.filter((accountToScrape) => accountToScrape.active !== false);
   for (let i = 0; i < accountsToScrape.length; i++) {
     const accountToScrape = accountsToScrape[i];
     const companyId = accountToScrape.key;
@@ -71,7 +71,7 @@ async function fetchTransactions(companyId: AccountToScrapeConfig['key'], creden
     companyId,
     credentials,
     startDate,
-    showBrowser: config.globalConfig.showBrowser,
+    showBrowser: config.scraping.showBrowser,
   });
   if (!scrapeResult.success) {
     console.error('Failed scraping ', companyId);

--- a/src/originalBudgetTrackingApp/index.ts
+++ b/src/originalBudgetTrackingApp/index.ts
@@ -25,7 +25,7 @@ export async function scrapeAndUpdateOutputVendors() {
   const config = await configManager.getConfig();
 
   const startDate = moment()
-    .subtract(config.scraping.numDaysBack, 'days')
+    .subtract(config.globalConfig.numDaysBack, 'days')
     .startOf('day')
     .toDate();
 
@@ -47,7 +47,7 @@ export async function scrapeAndUpdateOutputVendors() {
 
 async function scrapeFinancialAccountsAndFetchTransactions(config: Config, startDate: Date) {
   const companyIdToTransactions: Record<string, EnrichedTransaction[]> = {};
-  const accountsToScrape = config.scraping.accountsToScrape.filter((accountToScrape) => accountToScrape.active !== false);
+  const accountsToScrape = config.accountsToScrape.filter((accountToScrape) => accountToScrape.active !== false);
   for (let i = 0; i < accountsToScrape.length; i++) {
     const accountToScrape = accountsToScrape[i];
     const companyId = accountToScrape.key;
@@ -71,7 +71,7 @@ async function fetchTransactions(companyId: AccountToScrapeConfig['key'], creden
     companyId,
     credentials,
     startDate,
-    showBrowser: config.scraping.showBrowser,
+    showBrowser: config.globalConfig.showBrowser,
   });
   if (!scrapeResult.success) {
     console.error('Failed scraping ', companyId);

--- a/src/store/modules/Config.ts
+++ b/src/store/modules/Config.ts
@@ -8,28 +8,34 @@ export const ADD_EXPORTER_ACTION = 'ADD_EXPORTER_ACTION';
 export const REMOVE_IMPORTER_ACTION = 'REMOVE_IMPORTER_ACTION';
 export const GET_IMPORTERS_GETTER = 'GET_IMPORTERS_GETTER';
 export const GET_EXPORTER_GETTER = 'GET_EXPORTER_GETTER';
+export const GLOBAL_CONFIG_GETTER = 'GLOBAL_CONFIG_GETTER';
+export const UPDATE_GLOBAL_CONFIG_ACTION = 'UPDATE_GLOBAL_CONFIG_ACTION';
 
 const state: Config = defaultConfig;
 
 const mutations = <MutationTree<Config>>{
-  addImporter: (state: Config, importer) => state.scraping.accountsToScrape.push(importer),
+  addImporter: (state: Config, importer) => state.accountsToScrape.push(importer),
   removeImporter: (state: Config, importerId) => {
-    state.scraping.accountsToScrape = state.scraping.accountsToScrape.filter((importer) => importer.id !== importerId);
+    state.accountsToScrape = state.accountsToScrape.filter((importer) => importer.id !== importerId);
   },
   addExporter: (state: Config, { name, ...values }) => {
     state.outputVendors[name] = values;
   },
+  updateGlobalConfig: (state: Config, updatedConfig) => {
+    state.globalConfig = updatedConfig
+  }
 };
 
 const getters = <GetterTree<Config, any>>{
   [GET_IMPORTERS_GETTER]: (state) => {
-    const importers = state.scraping.accountsToScrape.map((importer) => {
+    const importers = state.accountsToScrape.map((importer) => {
       const status = {};
       return { ...importer, status };
     });
     return importers;
   },
-  [GET_EXPORTER_GETTER]: (state) => (name) => state.outputVendors[name]
+  [GET_EXPORTER_GETTER]: (state) => (name: string) => state.outputVendors[name],
+  [GLOBAL_CONFIG_GETTER]: ({ globalConfig }) => globalConfig
 };
 
 const actions = <ActionTree<Config, any>>{
@@ -42,6 +48,9 @@ const actions = <ActionTree<Config, any>>{
   },
   [ADD_EXPORTER_ACTION]: ({ commit }, { name, ...values }) => {
     commit('addExporter', { name, ...values });
+  },
+  [UPDATE_GLOBAL_CONFIG_ACTION]: ({ commit }, globalConfig) => {
+    commit('updateGlobalConfig', globalConfig)
   }
 };
 

--- a/src/store/modules/Config.ts
+++ b/src/store/modules/Config.ts
@@ -22,7 +22,7 @@ const mutations = <MutationTree<Config>>{
     state.outputVendors[name] = values;
   },
   updateGlobalConfig: (state: Config, updatedConfig) => {
-    state.globalConfig = updatedConfig
+    state.globalConfig = updatedConfig;
   }
 };
 
@@ -50,7 +50,7 @@ const actions = <ActionTree<Config, any>>{
     commit('addExporter', { name, ...values });
   },
   [UPDATE_GLOBAL_CONFIG_ACTION]: ({ commit }, globalConfig) => {
-    commit('updateGlobalConfig', globalConfig)
+    commit('updateGlobalConfig', globalConfig);
   }
 };
 

--- a/src/store/modules/Config.ts
+++ b/src/store/modules/Config.ts
@@ -3,6 +3,11 @@ import { Config, AccountToScrapeConfig } from '@/originalBudgetTrackingApp/confi
 import defaultConfig from '@/originalBudgetTrackingApp/configManager/defaultConfig';
 import { ActionTree, GetterTree, MutationTree } from 'vuex';
 
+type GlobalConfig = {
+  numDaysBack: number,
+  showBrowser: boolean
+}
+
 export const ADD_IMPORTER_ACTION = 'ADD_IMPORTER_ACTION';
 export const ADD_EXPORTER_ACTION = 'ADD_EXPORTER_ACTION';
 export const REMOVE_IMPORTER_ACTION = 'REMOVE_IMPORTER_ACTION';
@@ -14,28 +19,32 @@ export const UPDATE_GLOBAL_CONFIG_ACTION = 'UPDATE_GLOBAL_CONFIG_ACTION';
 const state: Config = defaultConfig;
 
 const mutations = <MutationTree<Config>>{
-  addImporter: (state: Config, importer: AccountToScrapeConfig) => state.accountsToScrape.push(importer),
+  addImporter: (state: Config, importer: AccountToScrapeConfig) => state.scraping.accountsToScrape.push(importer),
   removeImporter: (state: Config, importerId: string) => {
-    state.accountsToScrape = state.accountsToScrape.filter((importer) => importer.id !== importerId);
+    state.scraping.accountsToScrape = state.scraping.accountsToScrape.filter((importer) => importer.id !== importerId);
   },
   addExporter: (state: Config, { name, ...values }) => {
     state.outputVendors[name] = values;
   },
-  updateGlobalConfig: (state: Config, updatedConfig) => {
-    state.globalConfig = updatedConfig;
+  updateGlobalConfig: (state: Config, updatedConfig: GlobalConfig) => {
+    state.scraping.numDaysBack = updatedConfig.numDaysBack;
+    state.scraping.showBrowser = updatedConfig.showBrowser;
   }
 };
 
 const getters = <GetterTree<Config, any>>{
   [GET_IMPORTERS_GETTER]: (state) => {
-    const importers = state.accountsToScrape.map((importer) => {
+    const importers = state.scraping.accountsToScrape.map((importer) => {
       const status = {};
       return { ...importer, status };
     });
     return importers;
   },
   [GET_EXPORTER_GETTER]: (state) => (name: string) => state.outputVendors[name],
-  [GLOBAL_CONFIG_GETTER]: ({ globalConfig }) => globalConfig
+  [GLOBAL_CONFIG_GETTER]: ({ scraping }): GlobalConfig => {
+    const { numDaysBack, showBrowser } = scraping;
+    return { numDaysBack, showBrowser };
+  }
 };
 
 const actions = <ActionTree<Config, any>>{
@@ -49,7 +58,7 @@ const actions = <ActionTree<Config, any>>{
   [ADD_EXPORTER_ACTION]: ({ commit }, { name, ...values }) => {
     commit('addExporter', { name, ...values });
   },
-  [UPDATE_GLOBAL_CONFIG_ACTION]: ({ commit }, globalConfig) => {
+  [UPDATE_GLOBAL_CONFIG_ACTION]: ({ commit }, globalConfig: GlobalConfig) => {
     commit('updateGlobalConfig', globalConfig);
   }
 };

--- a/src/types/vuetify.ts
+++ b/src/types/vuetify.ts
@@ -1,0 +1,1 @@
+export type VForm = Vue & { validate: () => boolean }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17686879/90340830-7921bf80-e003-11ea-8bd2-0e17de79ede8.png)
![image](https://user-images.githubusercontent.com/17686879/90340832-7cb54680-e003-11ea-8a76-6940a9214c90.png)

In forms, we have two ways- make the form reactive so any change will **immediately update** the state and the config, and the other way- **clone** the editable object, make the changes and update the config **only when the user press "Send"**.

I prefer the second way (but I know nowadays the first way come to be common).

In the second way, in Vue, we have two ways:
 - Split the two-way binding by setting the value of the field with the **original value**, but listen to the `change` event to update the **local component state**, and send the updated state when the user submits.
 - Clone **the whole object** (by `JSON.parse(JSON.stringify` for example) and **bind** it to the UI.

In this form I selected the second way.