### PR TITLE
never print password

### DIFF
--- a/src/originalBudgetTrackingApp/bankScraper.ts
+++ b/src/originalBudgetTrackingApp/bankScraper.ts
@@ -22,7 +22,7 @@ export async function scrape({
   companyId, credentials, startDate, showBrowser = false
 }: ScrapeParameters) {
   if (!credentials || (!credentials.username && !credentials.num && !credentials.id) || !credentials.password) {
-    throw new Error(`Missing credentials for scraper. CompanyId: ${companyId}. Credentials: ${credentials && JSON.stringify(credentials)}`);
+    throw new Error(`Missing credentials for scraper. CompanyId: ${companyId}`);
   }
 
   const chromePath = await getChrome(undefined, console.log);


### PR DESCRIPTION
We have to be aware to keep the credentials safe as possible.
We can't use the credentials in any flow except from decryption to `israeli-bank-scrapers` and from input to encryption.

In the future we can consider to write a custom query in Semmle (or Checkmarx, I hope! :-) ) to find these paths.