### PR TITLE
Propose more accurate EventEmitter

### DIFF
--- a/src/originalBudgetTrackingApp/eventEmitters/EventEmitter.ts
+++ b/src/originalBudgetTrackingApp/eventEmitters/EventEmitter.ts
@@ -71,10 +71,4 @@ type EventDataMap = {
 
 type EmptyEvents = EventNames.IMPORT_PROCESS_START | EventNames.IMPORT_PROCESS_END | EventNames.EXPORT_PROCESS_START | EventNames.EXPORT_PROCESS_END;
 
-export class BudgetTrackingEventEmitter extends Emittery.Typed<EventDataMap, EmptyEvents> {
-
-}
-
-export type EventPublisher = Pick<BudgetTrackingEventEmitter, 'emit' | 'emitSerial'>
-
-export type EventSubscriber = Pick<BudgetTrackingEventEmitter, 'on' | 'once' | 'off' | 'onAny' | 'anyEvent' | 'offAny'>;
+export type EventPublisher = Pick<Emittery.Typed<EventDataMap, EmptyEvents>, 'emit'>

--- a/src/originalBudgetTrackingApp/eventEmitters/consoleEmitter.ts
+++ b/src/originalBudgetTrackingApp/eventEmitters/consoleEmitter.ts
@@ -1,11 +1,9 @@
 /* eslint-disable class-methods-use-this */
-import { BudgetTrackingEventEmitter, EventPublisher } from '@/originalBudgetTrackingApp/eventEmitters/EventEmitter';
+import { EventNames, EventPublisher } from '@/originalBudgetTrackingApp/eventEmitters/EventEmitter';
 
-export function buildConsoleEmitter(): EventPublisher {
-  const consoleEmitter = new BudgetTrackingEventEmitter();
-  consoleEmitter.onAny((eventName, eventData) => {
+export default class ConsoleEmitter implements EventPublisher {
+  async emit(eventName: EventNames, eventData?: any) {
     // eslint-disable-next-line no-console
     console.log(`${eventName}:`, eventData);
-  });
-  return consoleEmitter;
+  }
 }

--- a/src/originalBudgetTrackingApp/import/importTransactions.ts
+++ b/src/originalBudgetTrackingApp/import/importTransactions.ts
@@ -5,7 +5,8 @@ import { EnrichedTransaction } from '@/originalBudgetTrackingApp/commonTypes';
 import * as bankScraper from '@/originalBudgetTrackingApp/import/bankScraper';
 import { ScaperScrapingResult, Transaction } from '@/originalBudgetTrackingApp/import/bankScraper';
 import * as categoryCalculation from '@/originalBudgetTrackingApp/import/categoryCalculationScript';
-import { EventPublisher, EventNames, BudgetTrackingEventEmitter } from '../eventEmitters/EventEmitter';
+import Emittery from 'emittery';
+import { EventPublisher, EventNames } from '../eventEmitters/EventEmitter';
 
 type AccountToScrapeConfig = configManager.AccountToScrapeConfig;
 type Config = configManager.Config;
@@ -43,7 +44,7 @@ function buildImporterEvent(accountConfig: AccountToScrapeConfig, additionalPara
 }
 
 export async function getFinancialAccountNumbers() {
-  const eventEmitter = new BudgetTrackingEventEmitter();
+  const eventEmitter = new Emittery();
   const config = await configManager.getConfig();
 
   const startDate = moment()

--- a/src/originalBudgetTrackingApp/index.ts
+++ b/src/originalBudgetTrackingApp/index.ts
@@ -3,7 +3,7 @@ import { scrapeFinancialAccountsAndFetchTransactions } from '@/originalBudgetTra
 import moment from 'moment';
 import * as configManager from './configManager/configManager';
 import { EventPublisher, EventNames } from './eventEmitters/EventEmitter';
-import { buildConsoleEmitter } from './eventEmitters/consoleEmitter';
+import ConsoleEmitter from './eventEmitters/consoleEmitter';
 import outputVendors from './export/outputVendors';
 import * as bankScraper from './import/bankScraper';
 
@@ -14,7 +14,7 @@ export { configManager };
 export const { inputVendors } = bankScraper;
 
 export async function scrapeAndUpdateOutputVendors(optionalEventPublisher?: EventPublisher) {
-  const eventPublisher = optionalEventPublisher || buildConsoleEmitter();
+  const eventPublisher = optionalEventPublisher || new ConsoleEmitter();
   const config = await configManager.getConfig();
 
   const startDate = moment()


### PR DESCRIPTION
We already talked about that, but why I was thinking about the `EventPublisher` type?

Because this interface is the required interface by our process. We don't need to use `EventEmitter` just becuase there is one. All we can do is to follow its part of the interface, to let who use our method to use `EventEmitter` easily if he want to.

Just imagine the `EventEmitter` idea- it is a stand-alone object to implement *Producer-Consumer*, so both the Producer and Consumer are accessing to it.

But here, we have more coupled case, and it's OK, because we don't need a the idea of the `EventEmitter`, we just need a *Callback*.