### PR TITLE
Change exporters and importers ui idea

### DIFF
--- a/src/components/app/Exporters.vue
+++ b/src/components/app/Exporters.vue
@@ -3,31 +3,61 @@
     <v-toolbar>
       <v-toolbar-title>Exporters</v-toolbar-title>
     </v-toolbar>
-    <expansion-panel title="Json">
-      <json-exporter />
-    </expansion-panel>
-    <expansion-panel title="Ynab">
-      <ynab-exporter />
-    </expansion-panel>
-    <expansion-panel title="Google Sheets">
-      <google-sheets-exporter />
-    </expansion-panel>
+    <div class="exporterWrapper">
+      <expansion-panel
+        title="Json"
+        :logo-image="LOGO_IMAGES.json"
+      >
+        <json-exporter />
+      </expansion-panel>
+    </div>
+    <div class="exporterWrapper">
+      <expansion-panel
+        title="Ynab"
+        :logo-image="LOGO_IMAGES.ynab"
+      >
+        <ynab-exporter />
+      </expansion-panel>
+    </div>
+    <div class="exporterWrapper">
+      <expansion-panel
+        title="Google Sheets"
+        :logo-image="LOGO_IMAGES.googleSheets"
+      >
+        <google-sheets-exporter />
+      </expansion-panel>
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
+import { OutputVendorName } from '@/originalBudgetTrackingApp/configManager/configManager';
 import JsonExporter from './exporters/JsonExporter.vue';
 import GoogleSheetsExporter from './exporters/GoogleSheetsExporter.vue';
 import YnabExporter from './exporters/YnabExporter.vue';
 import ExpansionPanel from './exporters/ExpansionPanel.vue';
 
+const LOGO_IMAGES : Record<OutputVendorName, string> = {
+  googleSheets: 'googleSheets.jpg',
+  json: 'json.png',
+  ynab: 'ynab.jpg'
+};
+
 export default Vue.extend({
   components: {
     ExpansionPanel, JsonExporter, GoogleSheetsExporter, YnabExporter
   },
+  data() {
+    return {
+      LOGO_IMAGES
+    };
+  }
 });
 </script>
 
 <style scoped>
+  .exporterWrapper {
+    margin: 30px 0;
+  }
 </style>

--- a/src/components/app/exporters/ExpansionPanel.vue
+++ b/src/components/app/exporters/ExpansionPanel.vue
@@ -1,18 +1,30 @@
 <template>
-  <v-expansion-panels>
-    <v-expansion-panel>
-      <v-expansion-panel-header disable-icon-rotate>
-        {{ title }}
-      </v-expansion-panel-header>
-      <v-expansion-panel-content>
-        <slot />
-      </v-expansion-panel-content>
-    </v-expansion-panel>
-  </v-expansion-panels>
+  <v-dialog
+    v-model="showDialog"
+  >
+    <template v-slot:activator="{ on, attrs }">
+      <div>
+        <v-chip
+          v-bind="attrs"
+          :class="{ blue: enabled, 'lighten-4': true }"
+          v-on="on"
+        >
+          <v-avatar left>
+            <v-img :src="logoSrcWithPrefix" />
+          </v-avatar>
+          {{ title }}
+        </v-chip>
+      </div>
+    </template>
+    <div class="exporterSettingsWrapper">
+      <slot />
+    </div>
+  </v-dialog>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
+import { PUBLIC_BUCKET_URL_PREFIX } from '@/consts';
 
 export default Vue.extend({
   name: 'ExpansionPanel',
@@ -20,10 +32,32 @@ export default Vue.extend({
     title: {
       type: String,
       required: true,
+    },
+    logoImage: {
+      type: String,
+      default: 'piggy.png'
+    },
+    enabled: {
+      type: Boolean,
+      default: true
+    }
+  },
+  data() {
+    return {
+      showDialog: false,
+    };
+  },
+  computed: {
+    logoSrcWithPrefix() {
+      return `${PUBLIC_BUCKET_URL_PREFIX}/logos/${this.logoImage}`;
     }
   }
 });
 </script>
 
 <style>
+  .exporterSettingsWrapper {
+    background: white;
+    padding: 20px;
+  }
 </style>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,0 +1,1 @@
+export const PUBLIC_BUCKET_URL_PREFIX = 'https://budget-tracking-public.s3.eu-central-1.amazonaws.com';


### PR DESCRIPTION
I am thinking about changing the ui of importers and exporters from expandable panels to chips with icons that are clickable. Clicking on them will open the config in the modal.

These chips can also have an icon to indicate progress status.

This is an initial step in that direction. Still very ugly, but would like to get your feedback at this stage.

![Screen Shot 2020-09-22 at 0 26 38](https://user-images.githubusercontent.com/7272927/93823695-efe95280-fc6a-11ea-8195-4a3f5cbc81a0.png)
![Screen Shot 2020-09-22 at 0 26 46](https://user-images.githubusercontent.com/7272927/93823703-f37cd980-fc6a-11ea-8d81-e33fd0fc313b.png)
![Screen Shot 2020-09-22 at 0 27 03](https://user-images.githubusercontent.com/7272927/93823716-f677ca00-fc6a-11ea-9cb9-a03b6114002a.png)
